### PR TITLE
Keystone auth v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,18 +74,23 @@ that supports following options:
     --pid-file=PID_FILE   Full path to the pid file location
     --uid=UID             UID to drop the privileges to when in daemon mode
     --gid=GID             GID to drop the privileges to when in daemon mode
-    --keystone-auth       Use auth 2.0 (Keystone, requires keystoneclient)
+    --keystone-auth       Use OpenStack Identity Service (Keystone, requires keystoneclient)
+    --keystone-auth-version=VERSION
+                          Identity API version to be used, default: 2.0
     --keystone-region-name=REGION_NAME
-                          Region name to be used in auth 2.0
+                          Region name to be used in Keystone auth
     --keystone-tenant-separator=TENANT_SEPARATOR
                           Character used to separate tenant_name/username in
-                          auth 2.0, default: TENANT.USERNAME
+                          Keystone auth, default: TENANT.USERNAME
+    --keystone-domain-separator=DOMAIN_SEPARATOR
+                          Character used to separate project_name/project_domain_name
+                          and username/user_domain_name in Keystone auth v3, default: @
     --keystone-service-type=SERVICE_TYPE
-                          Service type to be used in auth 2.0, default: object-
-                          store
+                          Service type to be used in Keystone auth,
+                          default: object-store
     --keystone-endpoint-type=ENDPOINT_TYPE
-                          Endpoint type to be used in auth 2.0, default:
-                          publicURL
+                          Endpoint type to be used in Keystone auth,
+                          default: publicURL
     --config=CONFIG       Use an alternative configuration file
 
 The default location for the configuration file is /etc/sftpcloudfs.conf.
@@ -96,9 +101,9 @@ server must be secured to prevent unauthorized access to the cached data.
 By default Swift auth 1.0 will be used, and is compatible with OpenStack
 Object Storage (Swift) using swauth authentication middleware.
 
-Optionally OpenStack Identity Service 2.0 (*aka* keystone) can be used. Currently
-python-keystoneclient (0.3.2+) is required to use auth 2.0 and it can be enabled
-with *--keystone-auth* option. 
+Optionally OpenStack Identity Service (*aka* keystone) v2.0 or v3 can be used.
+Currently python-keystoneclient (0.3.2+ recommended) is required to use Keystone auth
+and it can be enabled with ``keystone-auth`` option.
 
 The server supports large files (over the 5GB default) by splitting the files
 in parts into a *.part* subdirectory and using a manifest file to access them as

--- a/sftpcloudfs.conf.example
+++ b/sftpcloudfs.conf.example
@@ -76,19 +76,26 @@
 # GID to drop privileges when in daemon mode.
 # gid = (empty)
 
-# Auth 2.0 (Keystone), requires keystoneclient
+# Use OpenStack Identity Service (Keystone), requires keystoneclient.
 # keystone-auth = no
 
-# Region name to be used with Auth 2.0 (optional)
+# Identity API version to be used with Keystone auth..
+# keystone-auth-version = 2.0
+
+# Region name to be used with Keystone auth (optional)
 # keystone-region-name = (empty)
 
-# Tenant separator to be used with Auth 2.0 (eg. TENANT.USERNAME)
+# Tenant separator to be used with Keystone auth (eg. TENANT.USERNAME)
 # keystone-tenant-separator = .
 
-# Service type to be used with Auth 2.0.
+# Domain separator to be used with Keystone auth v3 only
+# (eg. PROJECT_NAME@PROJECT_DOMAIN_NAME.USERNAME@USER_DOMAIN_NAME)
+# keystone-domain-separator = @
+
+# Service type to be used with Keystone auth.
 # keystone-service-type = object-store
 
-# Endpoint type to be used with Auth 2.0.
+# Endpoint type to be used with Keystone auth.
 # keystone-endpoint-type = publicURL
 
 # EOF

--- a/sftpcloudfs/main.py
+++ b/sftpcloudfs/main.py
@@ -127,10 +127,12 @@ class Main(object):
                                   'gid': None,
                                   'split-large-files': "0",
                                   'hide-part-dir': "no",
-                                  # keystone auth 2.0 support
+                                  # keystone auth support
                                   'keystone-auth': False,
+                                  'keystone-auth-version': '2.0',
                                   'keystone-region-name': None,
                                   'keystone-tenant-separator': default_ks_tenant_separator,
+                                  'keystone-domain-separator': '@',
                                   'keystone-service-type': default_ks_service_type,
                                   'keystone-endpoint-type': default_ks_endpoint_type,
                                   })
@@ -235,32 +237,45 @@ class Main(object):
                           action="store_true",
                           dest="keystone",
                           default=config.get('sftpcloudfs', 'keystone-auth'),
-                          help="Use auth 2.0 (Keystone, requires keystoneclient)")
+                          help="Use Keystone auth (requires keystoneclient)")
+
+        parser.add_option('--keystone-auth-version',
+                          type="str",
+                          dest="auth_version",
+                          default=config.get('sftpcloudfs', 'keystone-auth-version'),
+                          help="Identity API version to be used (default: 2.0)")
 
         parser.add_option('--keystone-region-name',
                           type="str",
                           dest="region_name",
                           default=config.get('sftpcloudfs', 'keystone-region-name'),
-                          help="Region name to be used in auth 2.0")
+                          help="Region name to be used in Keystone auth")
 
         parser.add_option('--keystone-tenant-separator',
                           type="str",
                           dest="tenant_separator",
                           default=config.get('sftpcloudfs', 'keystone-tenant-separator'),
-                          help="Character used to separate tenant_name/username in auth 2.0, " + \
+                          help="Character used to separate tenant_name/username in Keystone auth, " + \
                               "default: TENANT%sUSERNAME" % default_ks_tenant_separator)
+
+        parser.add_option('--keystone-domain-separator',
+                          type="str",
+                          dest="domain_separator",
+                          default=config.get('sftpcloudfs', 'keystone-domain-separator'),
+                          help="Character used to separate project_name/project_domain_name " + \
+                               "and username/user_domain_name in Keystone auth v3 (default: @)")
 
         parser.add_option('--keystone-service-type',
                           type="str",
                           dest="service_type",
                           default=config.get('sftpcloudfs', 'keystone-service-type'),
-                          help="Service type to be used in auth 2.0, default: %s" % default_ks_service_type)
+                          help="Service type to be used in Keystone auth, default: %s" % default_ks_service_type)
 
         parser.add_option('--keystone-endpoint-type',
                           type="str",
                           dest="endpoint_type",
                           default=config.get('sftpcloudfs', 'keystone-endpoint-type'),
-                          help="Endpoint type to be used in auth 2.0, default: %s" % default_ks_endpoint_type)
+                          help="Endpoint type to be used in Keystone auth, default: %s" % default_ks_endpoint_type)
 
         parser.add_option('--config',
                           type="str",
@@ -342,7 +357,7 @@ class Main(object):
         options.hide_part_dir = config.getboolean('sftpcloudfs', 'hide-part-dir')
 
         if options.keystone:
-            keystone_keys = ('region_name', 'tenant_separator', 'service_type', 'endpoint_type')
+            keystone_keys = ('auth_version', 'region_name', 'tenant_separator', 'domain_separator', 'service_type', 'endpoint_type')
             options.keystone = dict((key, getattr(options, key)) for key in keystone_keys)
 
         self.options = options


### PR DESCRIPTION
This PR adds support for OpenStack Identity Service (Keystone) v3.
Linked to  https://github.com/cloudfs/ftp-cloudfs/pull/67

Fix for issue #14 