### PR TITLE
Fix SCP upload chunk size

### DIFF
--- a/sftpcloudfs/scp.py
+++ b/sftpcloudfs/scp.py
@@ -203,6 +203,7 @@ class SCPHandler(threading.Thread):
             bytes_sent = 0
             while bytes_sent < size:
                 chunk = self.recv(self.CHUNK_SIZE)
+                chunk = chunk[:(size-bytes_sent)]
                 fd.write(chunk)
                 bytes_sent += len(chunk)
 


### PR DESCRIPTION
When a file si uploaded with SCP, if the remaining data size is not equal to ```self.CHUNK_SIZE```, chunk will contain SCP protocol data after the actual file data.
This patch sets ```chunk``` content correctly and fix this issue.